### PR TITLE
more cleanup

### DIFF
--- a/persistence/src/main/java/ca/mikegabelmann/demo2/persistence/facade/dto/PersonAddress.java
+++ b/persistence/src/main/java/ca/mikegabelmann/demo2/persistence/facade/dto/PersonAddress.java
@@ -2,16 +2,30 @@ package ca.mikegabelmann.demo2.persistence.facade.dto;
 
 import ca.mikegabelmann.demo2.persistence.model.Address;
 import ca.mikegabelmann.demo2.persistence.model.Person;
+import org.springframework.lang.Nullable;
 
 import java.util.Optional;
 
 
 public class PersonAddress {
     private final Person person;
+
+    @Nullable
     private final Address primaryAddress;
+
+    @Nullable
     private final Address secondaryAddress;
 
-    public PersonAddress(Person person, Address primaryAddress, Address secondaryAddress) {
+
+    public PersonAddress(final Person person) {
+        this(person, null, null);
+    }
+
+    public PersonAddress(final Person person, final Address primaryAddress, final Address secondaryAddress) {
+        if (person == null) {
+            throw new IllegalArgumentException("person is required");
+        }
+
         this.person = person;
         this.primaryAddress = primaryAddress;
         this.secondaryAddress = secondaryAddress;

--- a/persistence/src/main/java/ca/mikegabelmann/demo2/persistence/facade/dto/package-info.java
+++ b/persistence/src/main/java/ca/mikegabelmann/demo2/persistence/facade/dto/package-info.java
@@ -2,4 +2,7 @@
  * Contains Domain Transfer Objects (DTO) or composite objects. Used to make interaction with one or more service easier
  * when associations may not normally exist.
  */
+@NonNullFields
 package ca.mikegabelmann.demo2.persistence.facade.dto;
+
+import org.springframework.lang.NonNullFields;

--- a/persistence/src/main/java/ca/mikegabelmann/demo2/persistence/model/Address.java
+++ b/persistence/src/main/java/ca/mikegabelmann/demo2/persistence/model/Address.java
@@ -1,18 +1,27 @@
 package ca.mikegabelmann.demo2.persistence.model;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import org.springframework.lang.Nullable;
 
 
 @Entity
 @Table(name = "ADDRESS")
 public class Address {
-
     @Id
     @SequenceGenerator(name = "seq_address", sequenceName = "address_id_seq", allocationSize = 1)
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "seq_address")
     @Column(name = "ADDRESS_ID", nullable = false, unique = true)
     private Long id;
 
+    @Nullable
     @Column(name = "ATTENTION", length = 100)
     private String attention;
 
@@ -31,13 +40,14 @@ public class Address {
     @Column(name = "POSTAL", nullable = false, length = 25)
     private String postal;
 
+    @Nullable
     @ManyToOne
     @JoinColumn(name = "PERSON_ID")
     private Person person;
 
 
-    /** No args constructor. */
-    public Address() {}
+    /** No args constructor, used by JPA. */
+    protected Address() {}
 
     /** Required args constructor. */
     public Address(

--- a/persistence/src/main/java/ca/mikegabelmann/demo2/persistence/model/GroupCode.java
+++ b/persistence/src/main/java/ca/mikegabelmann/demo2/persistence/model/GroupCode.java
@@ -10,7 +10,6 @@ import jakarta.persistence.Table;
 @Entity
 @Table(name = "GROUP_CODE")
 public class GroupCode {
-
     @Id
     @Column(name = "GROUP_ID", nullable = false, unique = true, length = 5)
     private String groupId;
@@ -19,7 +18,7 @@ public class GroupCode {
     private String description;
 
 
-    /** No args constructor. */
+    /** No args constructor, used by JPA. */
     protected GroupCode() {
         this(null, null);
     }

--- a/persistence/src/main/java/ca/mikegabelmann/demo2/persistence/model/GroupTypeCode.java
+++ b/persistence/src/main/java/ca/mikegabelmann/demo2/persistence/model/GroupTypeCode.java
@@ -9,7 +9,6 @@ import java.util.List;
 @Entity
 @Table(name = "GROUP_TYPE_CODE")
 public class GroupTypeCode {
-
     @EmbeddedId
     private GroupTypeCodeId id;
 
@@ -37,7 +36,8 @@ public class GroupTypeCode {
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "groupTypeCode")
     private List<GroupTypeCode> groupTypeCodes;
 
-    /** No args constructor. */
+
+    /** No args constructor, used by JPA. */
     protected GroupTypeCode() {
         this(null, null, 0, null, null, null);
     }

--- a/persistence/src/main/java/ca/mikegabelmann/demo2/persistence/model/GroupTypeCodeId.java
+++ b/persistence/src/main/java/ca/mikegabelmann/demo2/persistence/model/GroupTypeCodeId.java
@@ -8,7 +8,6 @@ import java.io.Serializable;
 
 @Embeddable
 public class GroupTypeCodeId implements Serializable {
-
     @Column(name = "GROUP_ID", nullable = false, length = 5)
     private String groupId;
 
@@ -16,7 +15,7 @@ public class GroupTypeCodeId implements Serializable {
     private String typeId;
 
 
-    /** No args constructor. */
+    /** No args constructor, used by JPA. */
     protected GroupTypeCodeId() {
         this(null, null);
     }

--- a/persistence/src/main/java/ca/mikegabelmann/demo2/persistence/model/Person.java
+++ b/persistence/src/main/java/ca/mikegabelmann/demo2/persistence/model/Person.java
@@ -1,6 +1,17 @@
 package ca.mikegabelmann.demo2.persistence.model;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import org.springframework.lang.Nullable;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -23,6 +34,7 @@ public class Person {
     @Column(name = "LAST_NAME", length = 75, nullable = false)
     private String lastName;
 
+    @Nullable
     @Column(name = "MIDDLE_NAME", length = 75)
     private String middleName;
 
@@ -37,8 +49,8 @@ public class Person {
     private List<Address> addresses = new ArrayList<>();
 
 
-    /** No args constructor. */
-    public Person() {}
+    /** No args constructor, used by JPA. */
+    protected Person() {}
 
     /** Required args constructor. */
     public Person(

--- a/persistence/src/main/java/ca/mikegabelmann/demo2/persistence/model/SexCode.java
+++ b/persistence/src/main/java/ca/mikegabelmann/demo2/persistence/model/SexCode.java
@@ -1,15 +1,14 @@
 package ca.mikegabelmann.demo2.persistence.model;
 
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 
+
 @Entity
 @Table(name = "SEX_CODE")
 public class SexCode {
-
     @Id
     @Column(name = "ID", length = 1, nullable = false, unique = true)
     private String id;
@@ -18,8 +17,8 @@ public class SexCode {
     private String description;
 
 
-    /** No args constructor. */
-    public SexCode() {
+    /** No args constructor, used by JPA. */
+    protected SexCode() {
         this(null, null);
     }
 

--- a/persistence/src/main/java/ca/mikegabelmann/demo2/persistence/model/package-info.java
+++ b/persistence/src/main/java/ca/mikegabelmann/demo2/persistence/model/package-info.java
@@ -1,4 +1,7 @@
 /**
  * This package contains all the classes that support mapping between the database and application using JPA.
  */
+@NonNullFields
 package ca.mikegabelmann.demo2.persistence.model;
+
+import org.springframework.lang.NonNullFields;

--- a/persistence/src/main/java/ca/mikegabelmann/demo2/persistence/service/PersonServiceImpl.java
+++ b/persistence/src/main/java/ca/mikegabelmann/demo2/persistence/service/PersonServiceImpl.java
@@ -39,6 +39,4 @@ public class PersonServiceImpl implements PersonService {
         return personRepository.save(p);
     }
 
-
-
 }

--- a/persistence/src/main/java/ca/mikegabelmann/demo2/persistence/service/package-info.java
+++ b/persistence/src/main/java/ca/mikegabelmann/demo2/persistence/service/package-info.java
@@ -1,6 +1,6 @@
 /**
- * Interfaces and implementations for the service layer. All logic, validation, packaging and unpackaging of data from
- * database are controlled here. If there are errors, exceptions should be thrown so they can be handled at another
+ * Interfaces and implementations for the service layer. All logic, validation, packaging and un-packaging of data from
+ * database are controlled here. If there are errors, exceptions should be thrown, so they can be handled at another
  * layer.
  */
 package ca.mikegabelmann.demo2.persistence.service;

--- a/persistence/src/test/java/ca/mikegabelmann/demo2/persistence/facade/PersonFacadeImplTest.java
+++ b/persistence/src/test/java/ca/mikegabelmann/demo2/persistence/facade/PersonFacadeImplTest.java
@@ -1,7 +1,7 @@
-package ca.mikegabelmann.demo2.persistence.service.facade;
+package ca.mikegabelmann.demo2.persistence.facade;
 
-import ca.mikegabelmann.demo2.persistence.facade.PersonFacadeImpl;
 import ca.mikegabelmann.demo2.persistence.model.Address;
+import ca.mikegabelmann.demo2.persistence.model.ModelFactory;
 import ca.mikegabelmann.demo2.persistence.model.Person;
 import ca.mikegabelmann.demo2.persistence.repository.AddressRepository;
 import ca.mikegabelmann.demo2.persistence.repository.PersonRepository;
@@ -37,8 +37,8 @@ public class PersonFacadeImplTest {
 
     @BeforeEach
     void beforeEach() {
-        this.person = new Person();
-        this.address = new Address();
+        this.person = ModelFactory.getPerson_Male();
+        this.address = ModelFactory.getAddress(person);
         person.getAddresses().add(address);
     }
 

--- a/persistence/src/test/java/ca/mikegabelmann/demo2/persistence/facade/dto/PersonAddressTest.java
+++ b/persistence/src/test/java/ca/mikegabelmann/demo2/persistence/facade/dto/PersonAddressTest.java
@@ -1,0 +1,47 @@
+package ca.mikegabelmann.demo2.persistence.facade.dto;
+
+import ca.mikegabelmann.demo2.persistence.model.Address;
+import ca.mikegabelmann.demo2.persistence.model.ModelFactory;
+import ca.mikegabelmann.demo2.persistence.model.Person;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+
+class PersonAddressTest {
+
+    @Test
+    @DisplayName("no args constructor - invalid arguments")
+    void test1_constructor() {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new PersonAddress(null));
+    }
+
+    @Test
+    void getPerson() {
+        Person person1 = ModelFactory.getPerson_Male();
+        PersonAddress personAddress1 = new PersonAddress(person1, null, null);
+
+        Assertions.assertNotNull(personAddress1.getPerson());
+    }
+
+    @Test
+    void getPrimaryAddress() {
+        Person person1 = ModelFactory.getPerson_Male();
+        Address address1 = ModelFactory.getAddress(person1);
+        PersonAddress personAddress1 = new PersonAddress(person1, address1, null);
+
+        Assertions.assertTrue(personAddress1.getPrimaryAddress().isPresent());
+        Assertions.assertTrue(personAddress1.getSecondaryAddress().isEmpty());
+    }
+
+    @Test
+    void getSecondaryAddress() {
+        Person person1 = ModelFactory.getPerson_Male();
+        Address address1 = ModelFactory.getAddress(person1);
+        PersonAddress personAddress1 = new PersonAddress(person1, null, address1);
+
+        Assertions.assertTrue(personAddress1.getPrimaryAddress().isEmpty());
+        Assertions.assertTrue(personAddress1.getSecondaryAddress().isPresent());
+    }
+
+}

--- a/persistence/src/test/java/ca/mikegabelmann/demo2/persistence/model/ModelFactory.java
+++ b/persistence/src/test/java/ca/mikegabelmann/demo2/persistence/model/ModelFactory.java
@@ -1,0 +1,38 @@
+package ca.mikegabelmann.demo2.persistence.model;
+
+import ca.mikegabelmann.demo2.persistence.model.SexCode;
+
+import java.time.LocalDate;
+
+/**
+ * Used to construct Model/JPA objects with 'sane' defaults.
+ */
+public class ModelFactory {
+    /** Do not instantiate this class. */
+    private ModelFactory() {}
+
+    public static SexCode getSexCode_Male() {
+        return new SexCode("M", "Male");
+    }
+
+    public static SexCode getSexCode_Female() {
+        return new SexCode("F", "Female");
+    }
+
+    public static Person getPerson(final SexCode sexCode) {
+        return new Person(null, "firstName", "lastName", LocalDate.now(), sexCode);
+    }
+
+    public static Person getPerson_Male() {
+        return getPerson(getSexCode_Male());
+    }
+
+    public static Person getPerson_Female() {
+        return getPerson(getSexCode_Female());
+    }
+
+    public static Address getAddress(final Person person) {
+        return new Address(null, "streetAddress", "city", "prov", "country", "postal", person);
+    }
+
+}

--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -47,6 +47,7 @@
             <groupId>org.mapstruct</groupId>
             <artifactId>mapstruct</artifactId>
             <version>${mapstruct.version}</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>
@@ -104,10 +105,19 @@
         <dependency>
             <groupId>org.glassfish.jaxb</groupId>
             <artifactId>jaxb-runtime</artifactId>
-            <version>4.0.0</version>
+            <version>4.0.1</version>
             <scope>compile</scope>
         </dependency>
 
+
+        <!-- TEST -->
+        <dependency>
+            <groupId>ca.mikegabelmann</groupId>
+            <artifactId>demo-rest2-persistence</artifactId>
+            <version>0.1-SNAPSHOT</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>

--- a/rest/src/test/java/ca/mikegabelmann/demo2/controller/rest/AddressRestControllerTest.java
+++ b/rest/src/test/java/ca/mikegabelmann/demo2/controller/rest/AddressRestControllerTest.java
@@ -2,6 +2,7 @@ package ca.mikegabelmann.demo2.controller.rest;
 
 import ca.mikegabelmann.demo2.controller.rest.mapper.DtoMapper;
 import ca.mikegabelmann.demo2.persistence.model.Address;
+import ca.mikegabelmann.demo2.persistence.model.ModelFactory;
 import ca.mikegabelmann.demo2.persistence.model.Person;
 import ca.mikegabelmann.demo2.persistence.service.AddressService;
 import org.junit.jupiter.api.BeforeEach;
@@ -42,7 +43,9 @@ public class AddressRestControllerTest {
 
     @BeforeEach
     void beforeEach() {
-        this.address = new Address(1L, "streetAddress", "city", "prov", "country", "postal", new Person());
+        Person person1 = ModelFactory.getPerson_Male();
+        this.address = ModelFactory.getAddress(person1);
+        this.address.setId(1L);
     }
 
     @Test

--- a/rest/src/test/java/ca/mikegabelmann/demo2/controller/rest/PersonAddressRestControllerTest.java
+++ b/rest/src/test/java/ca/mikegabelmann/demo2/controller/rest/PersonAddressRestControllerTest.java
@@ -2,8 +2,8 @@ package ca.mikegabelmann.demo2.controller.rest;
 
 import ca.mikegabelmann.demo2.controller.rest.mapper.DtoMapper;
 import ca.mikegabelmann.demo2.persistence.model.Address;
+import ca.mikegabelmann.demo2.persistence.model.ModelFactory;
 import ca.mikegabelmann.demo2.persistence.model.Person;
-import ca.mikegabelmann.demo2.persistence.model.SexCode;
 import ca.mikegabelmann.demo2.persistence.facade.PersonFacade;
 import ca.mikegabelmann.demo2.persistence.facade.dto.PersonAddress;
 import org.junit.jupiter.api.BeforeEach;
@@ -44,8 +44,10 @@ public class PersonAddressRestControllerTest {
 
     @BeforeEach
     void beforeEach() {
-        this.personAddress = new PersonAddress(new Person(), new Address(), new Address());
-        personAddress.getPerson().setSexCode(new SexCode());
+        Person person1 = ModelFactory.getPerson_Male();
+        Address address1 = ModelFactory.getAddress(person1);
+        Address address2 = ModelFactory.getAddress(person1);
+        this.personAddress = new PersonAddress(person1, address1, address2);
     }
 
     @Disabled("failing")

--- a/rest/src/test/java/ca/mikegabelmann/demo2/controller/rest/PersonRestControllerIT.java
+++ b/rest/src/test/java/ca/mikegabelmann/demo2/controller/rest/PersonRestControllerIT.java
@@ -1,7 +1,7 @@
 package ca.mikegabelmann.demo2.controller.rest;
 
+import ca.mikegabelmann.demo2.persistence.model.ModelFactory;
 import ca.mikegabelmann.demo2.persistence.model.Person;
-import ca.mikegabelmann.demo2.codes.Sex;
 import ca.mikegabelmann.demo2.persistence.model.SexCode;
 import ca.mikegabelmann.demo2.persistence.repository.PersonRepository;
 import ca.mikegabelmann.demo2.persistence.repository.SexCodeRepository;
@@ -42,10 +42,10 @@ public class PersonRestControllerIT {
     void beforeEach() {
         this.now = LocalDate.now();
 
-        SexCode sTmp = new SexCode(Sex.F.name(), Sex.F.toString());
+        SexCode sTmp = ModelFactory.getSexCode_Male();
         this.s = sexCodeRepository.save(sTmp);
 
-        Person pTmp = new Person(null, "firstName", "lastName", now, s);
+        Person pTmp = ModelFactory.getPerson(s);
         this.p = personRepository.save(pTmp);
     }
 

--- a/rest/src/test/java/ca/mikegabelmann/demo2/controller/rest/PersonRestControllerTest.java
+++ b/rest/src/test/java/ca/mikegabelmann/demo2/controller/rest/PersonRestControllerTest.java
@@ -2,6 +2,7 @@ package ca.mikegabelmann.demo2.controller.rest;
 
 import ca.mikegabelmann.demo2.codes.Sex;
 import ca.mikegabelmann.demo2.controller.rest.mapper.DtoMapper;
+import ca.mikegabelmann.demo2.persistence.model.ModelFactory;
 import ca.mikegabelmann.demo2.persistence.model.Person;
 import ca.mikegabelmann.demo2.persistence.model.SexCode;
 import ca.mikegabelmann.demo2.persistence.service.PersonService;
@@ -44,7 +45,7 @@ class PersonRestControllerTest {
 
     @BeforeEach
     void beforeEach() {
-        SexCode sexCode = new SexCode(Sex.M.name(), Sex.M.toString());
+        SexCode sexCode = ModelFactory.getSexCode_Male();
         this.person = new Person(1L, "firstName", "lastName", LocalDate.of(2000, 1, 15), sexCode);
     }
 

--- a/rest/src/test/java/ca/mikegabelmann/demo2/controller/rest/mapper/DtoMapperTest.java
+++ b/rest/src/test/java/ca/mikegabelmann/demo2/controller/rest/mapper/DtoMapperTest.java
@@ -3,16 +3,15 @@ package ca.mikegabelmann.demo2.controller.rest.mapper;
 import ca.mikegabelmann.demo2.dto.AddressDto;
 import ca.mikegabelmann.demo2.dto.PersonAddressDto;
 import ca.mikegabelmann.demo2.dto.PersonDto;
-import ca.mikegabelmann.demo2.persistence.model.Address;
-import ca.mikegabelmann.demo2.persistence.model.Person;
-import ca.mikegabelmann.demo2.persistence.model.SexCode;
 import ca.mikegabelmann.demo2.persistence.facade.dto.PersonAddress;
+import ca.mikegabelmann.demo2.persistence.model.Address;
+import ca.mikegabelmann.demo2.persistence.model.ModelFactory;
+import ca.mikegabelmann.demo2.persistence.model.Person;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import java.time.LocalDate;
 import java.util.List;
 
 
@@ -20,25 +19,26 @@ import java.util.List;
  * Unit tests for bean mapping.
  */
 class DtoMapperTest {
-
     private final DtoMapper mapper = new DtoMapperImpl();
 
     private Person person1;
-    private PersonDto personDto1;
     private Address address1;
-    private AddressDto addressDto1;
     private PersonAddress personAddress1;
-    private PersonAddressDto personAddressDto1;
+
+    //private PersonDto personDto1;
+    //private AddressDto addressDto1;
+    //private PersonAddressDto personAddressDto1;
 
 
     @BeforeEach
     void setUp() {
-        this.person1 = new Person(1L, "firstName", "lastName", LocalDate.now(), new SexCode("M", "Male"));
-        this.personDto1 = new PersonDto(1L, "firstName", "lastName", "middleName", LocalDate.now(), "M");
-        this.address1 = new Address(1L, "streetAddress", "city", "prov", "country", "postal", person1);
-        this.addressDto1 = new AddressDto(1L, "attention", "streetAddress", "city", "prov", "country", "postal");
+        this.person1 = ModelFactory.getPerson_Male();
+        this.address1 = ModelFactory.getAddress(person1);
         this.personAddress1 = new PersonAddress(person1, address1, address1);
-        this.personAddressDto1 = new PersonAddressDto(personDto1, addressDto1, addressDto1);
+
+        //this.addressDto1 = new AddressDto(1L, "attention", "streetAddress", "city", "prov", "country", "postal");
+        //this.personDto1 = new PersonDto(1L, "firstName", "lastName", "middleName", LocalDate.now(), "M");
+        //this.personAddressDto1 = new PersonAddressDto(personDto1, addressDto1, addressDto1);
     }
 
     @Test
@@ -58,23 +58,6 @@ class DtoMapperTest {
         this.validate(person1, result);
     }
 
-    /*@Test
-    @DisplayName("PersonDto > Person - null")
-    void test1_mapPerson() {
-        Person result = mapper.mapPerson(null);
-
-        Assertions.assertNull(result);
-    }
-
-    @Test
-    @DisplayName("PersonDto > Person - not null")
-    void test2_mapPerson() {
-        Person result = mapper.mapPerson(personDto1);
-
-        Assertions.assertNotNull(result);
-        this.validate(personDto1, result);
-    }*/
-
     @Test
     @DisplayName("List Person > PersonDto - null")
     void test1_mapListPersonDto() {
@@ -92,6 +75,41 @@ class DtoMapperTest {
         Assertions.assertEquals(1, results.size());
         this.validate(person1, results.get(0));
     }
+
+    @Test
+    @DisplayName("List Address > AddressDto - null")
+    void test1_mapListAddressDto() {
+        List<AddressDto> results = mapper.mapListAddressDto(null);
+
+        Assertions.assertNull(results);
+    }
+
+    @Test
+    @DisplayName("List Address > AddressDto - not null")
+    void test2_mapListAddressDto() {
+        List<AddressDto> results = mapper.mapListAddressDto(List.of(address1));
+
+        Assertions.assertNotNull(results);
+        Assertions.assertEquals(1, results.size());
+        this.validate(address1, results.get(0));
+    }
+
+    /*@Test
+    @DisplayName("PersonDto > Person - null")
+    void test1_mapPerson() {
+        Person result = mapper.mapPerson(null);
+
+        Assertions.assertNull(result);
+    }
+
+    @Test
+    @DisplayName("PersonDto > Person - not null")
+    void test2_mapPerson() {
+        Person result = mapper.mapPerson(personDto1);
+
+        Assertions.assertNotNull(result);
+        this.validate(personDto1, result);
+    }*/
 
     /*@Test
     @DisplayName("List PersonDto > Person - null")
@@ -145,24 +163,6 @@ class DtoMapperTest {
         Assertions.assertNotNull(result);
         this.validate(addressDto1, result);
     }*/
-
-    @Test
-    @DisplayName("List Address > AddressDto - null")
-    void test1_mapListAddressDto() {
-        List<AddressDto> results = mapper.mapListAddressDto(null);
-
-        Assertions.assertNull(results);
-    }
-
-    @Test
-    @DisplayName("List Address > AddressDto - not null")
-    void test2_mapListAddressDto() {
-        List<AddressDto> results = mapper.mapListAddressDto(List.of(address1));
-
-        Assertions.assertNotNull(results);
-        Assertions.assertEquals(1, results.size());
-        this.validate(address1, results.get(0));
-    }
 
     /*@Test
     @DisplayName("List AddressDto > Address - null")


### PR DESCRIPTION
added ModelFactory which can be used to create 'sane' Model objects with defaults usable for testing. DB generated PKs are not populated by default. added @NonNullFields to model and facade/dto package-info.java rest module tests import persistence test jar to access ModelFactory moved PersonFacadeImplTest to proper location
made model 'no args constructor' protected since only JPA should be using those, can't make private as JPA needs to proxy them.